### PR TITLE
Added executedBy field to idenitfy if the command was executed by HANA RP

### DIFF
--- a/lib/fluent/plugin/filter_hanarp_message.rb
+++ b/lib/fluent/plugin/filter_hanarp_message.rb
@@ -20,13 +20,14 @@ module Fluent::Plugin
       host = record[ucsHostNameKey]
       chassis = message[/chassis-(\d)/,1]
       blade = message[/blade-(\d)/,1]
+      executedBy = record["executedBy"]
 
       if record.key?("machineId")
         machineId = record["machineId"]
         serviceProfile = machineId.split(":")[2]
       end
 
-      d = Data.new(machineId, host, chassis, blade, serviceProfile, event, stage, message)
+      d = Data.new(machineId, host, chassis, blade, serviceProfile, event, stage, message, executedBy)
       m = Message.new(time, event, d)
       record["message"] = m.to_json
       record
@@ -78,7 +79,7 @@ module Fluent::Plugin
       RESTART+STAGE_END         => STARTED
     }
 
-    def initialize(machineId, hostname, chassis, blade, serviceProfile, event, stage, message)
+    def initialize(machineId, hostname, chassis, blade, serviceProfile, event, stage, message, executedBy)
       @machineId = machineId
       @hostname = hostname
       @chassis = chassis
@@ -86,6 +87,7 @@ module Fluent::Plugin
       @serviceProfile = serviceProfile
       @stage = stage
       @message = message
+      @executedBy = executedBy
 
       eventLower = event.downcase
       stageLower = stage.downcase
@@ -105,7 +107,8 @@ module Fluent::Plugin
         serviceProfile: @serviceProfile,
         stage: @stage,
         state: @state,
-        message: @message
+        message: @message,
+        executedBy: @executedBy
       }.to_json(*a)
     end
   end

--- a/test/test_filter_hanarp_message.rb
+++ b/test/test_filter_hanarp_message.rb
@@ -39,7 +39,8 @@ class AddServiceProfile < Test::Unit::TestCase
                 "machineId" => "Cisco_UCS:SJC2:testServiceProfile",
                 "SyslogSource" => "1.1.1.1",
                 "event" => "Soft Shutdown",
-                "stage" => "begin"
+                "stage" => "begin",
+                "executedBy" => "domain\\username"
             }
         ]
         filtered_records = filter(messages)
@@ -53,6 +54,7 @@ class AddServiceProfile < Test::Unit::TestCase
         assert_equal "testServiceProfile", data['data']['serviceProfile']
         assert_equal "begin", data['data']['stage']
         assert_equal "stopping", data['data']['state']
+        assert_equal "domain\\username", data['data']['executedBy']
         
         assert_equal "Cisco_UCS:SJC2:testServiceProfile", filtered_records[0]['machineId']
         assert_equal "1.1.1.1", filtered_records[0]['SyslogSource']
@@ -64,7 +66,8 @@ class AddServiceProfile < Test::Unit::TestCase
                 "message" => ": 2018 Feb  9 21:07:41 GMT: %UCSM-6-EVENT: [] [FSM:BEGIN]: Soft shutdown of server sys/chassis-4/blade-7",
                 "SyslogSource" => "1.1.1.1",
                 "event" => "Restart",
-                "stage" => "end"
+                "stage" => "end",
+                "executedBy" => ""
             }
         ]
         filtered_records = filter(messages)
@@ -78,6 +81,7 @@ class AddServiceProfile < Test::Unit::TestCase
         assert_equal nil, data['data']['serviceProfile']
         assert_equal "end", data['data']['stage']
         assert_equal "started", data['data']['state']
+        assert_equal "", data['data']['executedBy']
         
         assert_equal nil, filtered_records[0]['machineId']
         assert_equal "1.1.1.1", filtered_records[0]['SyslogSource']
@@ -90,7 +94,8 @@ class AddServiceProfile < Test::Unit::TestCase
                 "machineId" => "Cisco_UCS:SJC2:testServiceProfile",
                 "SyslogSource" => "1.1.1.1",
                 "event" => "Unknown Event",
-                "stage" => "begin"
+                "stage" => "begin",
+                "executedBy" => ""
             }
         ]
         filtered_records = filter(messages)
@@ -104,6 +109,7 @@ class AddServiceProfile < Test::Unit::TestCase
         assert_equal "testServiceProfile", data['data']['serviceProfile']
         assert_equal "begin", data['data']['stage']
         assert_equal "unknown", data['data']['state']
+        assert_equal "", data['data']['executedBy']
         
         assert_equal "Cisco_UCS:SJC2:testServiceProfile", filtered_records[0]['machineId']
         assert_equal "1.1.1.1", filtered_records[0]['SyslogSource']


### PR DESCRIPTION
Added executedBy field to idenitfy if the command was executed by HANA RP
This will be used by ColoAdapter to better correlate a powerstate change with an operation.

Work Item: https://msazure.visualstudio.com/One/_workitems/edit/3324831